### PR TITLE
同じタグを違うユーザーが登録した時の挙動の修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -48,7 +48,7 @@ class PostsController < ApplicationController
 
   def set_tags
     @tag_name = params[:tag]
-    @tags = TagManagement.where(tag: @tag_name).order(:order)
+    @tags = current_user.tag_managements.where(tag: @tag_name).order(:order)
     @user_having_tags = current_user.tag_managements.select(:tag).uniq{|i| i.tag}
   end
 


### PR DESCRIPTION
- [x] TagManagement.where() を current_user.tag_managements.where() に修正した。